### PR TITLE
logging: console output

### DIFF
--- a/RemnantOverseer/RemnantOverseer.csproj
+++ b/RemnantOverseer/RemnantOverseer.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
   </ItemGroup>
 

--- a/RemnantOverseer/Services/Log.cs
+++ b/RemnantOverseer/Services/Log.cs
@@ -38,6 +38,7 @@ internal class Log
         else
         {
             config = new LoggerConfiguration()
+                .WriteTo.Console()
                 .WriteTo.File(template, LogFilePath);
         }
 


### PR DESCRIPTION
This is incredibly helpful for debugging issues with e.g. the logging itself since that may not be visible otherwise. It is also the primary way for people on some platforms (Linux for example) to see logs during development, but it probably also applies to IDEs in general.

---

Above is the commit message verbatim.

Not sure about also using the template, it seems that most information is present either way, with the notable differences of a different time format and *the console output having colour* which is *really* useful to get around the logs faster, so I'm conflicted on applying the template as is.
At least I didn't spot any differences on a glance.

Either way it's really nice for development.