### PR TITLE
Limited support for Linux build and GitHub Actions based automated build

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,43 @@
+name: .NET
+
+on:
+  push:
+    tags:
+    - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Set Version Variable
+      if: ${{ github.ref_type == 'tag' }}
+      env:
+        TAG: ${{ github.ref_name }}
+      run: echo "VERSION=${TAG#v}" >> $GITHUB_ENV
+    - name: Build for Windows
+      run: dotnet publish --runtime win-x64 -p:PublishSingleFile=true -p:Version=$VERSION -p:AssemblyVersion=$VERSION
+    - name: Build for Linux
+      run: dotnet publish --runtime linux-x64 -p:PublishSingleFile=true -p:Version=$VERSION -p:AssemblyVersion=$VERSION
+    - name: Create Linux artifact
+      run: |
+        tar -C ./RemnantOverseer/bin/Release/net8.0/linux-x64/publish -czvf RemnantOverseer-${{ github.ref_name }}-linux.tar.gz .
+    - name: Create Windows artifact
+      run: |
+        zip -j RemnantOverseer-${{ github.ref_name }}-windows.zip ./RemnantOverseer/bin/Release/net8.0/win-x64/publish/*
+    - name: Create Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          RemnantOverseer-${{ github.ref_name }}-linux.tar.gz
+          RemnantOverseer-${{ github.ref_name }}-windows.zip
+
+

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,9 +24,9 @@ jobs:
         TAG: ${{ github.ref_name }}
       run: echo "VERSION=${TAG#v}" >> $GITHUB_ENV
     - name: Build for Windows
-      run: dotnet publish --runtime win-x64 -p:PublishSingleFile=true -p:Version=$VERSION -p:AssemblyVersion=$VERSION
+      run: dotnet publish --runtime win-x64 -p:PublishSingleFile=true -p:SelfContained=false -p:Version=$VERSION -p:AssemblyVersion=$VERSION
     - name: Build for Linux
-      run: dotnet publish --runtime linux-x64 -p:PublishSingleFile=true -p:Version=$VERSION -p:AssemblyVersion=$VERSION
+      run: dotnet publish --runtime linux-x64 -p:PublishSingleFile=true -p:SelfContained=false -p:Version=$VERSION -p:AssemblyVersion=$VERSION
     - name: Create Linux artifact
       run: |
         tar -C ./RemnantOverseer/bin/Release/net8.0/linux-x64/publish -czvf RemnantOverseer-${{ github.ref_name }}-linux.tar.gz .

--- a/RemnantOverseer/Program.cs
+++ b/RemnantOverseer/Program.cs
@@ -3,20 +3,21 @@ using RemnantOverseer.Services;
 using RemnantOverseer.Utilities;
 using System;
 using System.Threading;
+using System.Runtime.InteropServices;
 
 namespace RemnantOverseer;
 
 internal sealed class Program
 {
     // Allow only one instance: https://stackoverflow.com/questions/19147/what-is-the-correct-way-to-create-a-single-instance-wpf-application/522874#522874
-    static Mutex mutex = new Mutex(true, "{RO-F7F5EC79-F2CF-4645-820D-241A4E4E6E1A}");
+    static Mutex mutex = new Mutex(false, @"Global\{RO-F7F5EC79-F2CF-4645-820D-241A4E4E6E1A}");
     // Initialization code. Don't use any Avalonia, third-party APIs or any
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.
     [STAThread]
     public static void Main(string[] args)
     {
-        if (mutex.WaitOne(TimeSpan.Zero, true))
+        if (mutex.WaitOne(TimeSpan.Zero, false))
         {
             BuildAvaloniaApp()
                 .StartWithClassicDesktopLifetime(args);
@@ -25,11 +26,16 @@ internal sealed class Program
         }
         else
         {
-            NativeMethods.PostMessage(
-                (IntPtr)NativeMethods.HWND_BROADCAST,
-                NativeMethods.RO_WM_SHOWME,
-                IntPtr.Zero,
-                IntPtr.Zero);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+              NativeMethods.PostMessage(
+                  (IntPtr)NativeMethods.HWND_BROADCAST,
+                  NativeMethods.RO_WM_SHOWME,
+                  IntPtr.Zero,
+                  IntPtr.Zero);
+            } else {
+              Console.WriteLine("The application is already running");
+            }
         }
     }
 


### PR DESCRIPTION
- GitHub actions is configured to run everytime a new tag in the `v1.2.3` format is created and pushed to create a new release with Linux and Windows binaries attached.
- Release notes won't be included, since we currently have no other place for them but the release itself. Either edit the release to edit-in the notes, or better yet, create a trackable, source controlled release notes, GitHub releases could reference.
- Mutex functionality is reworked to support Linux. I tested it both on Windows and Linux, but please do let me know if you see any unintended issues
- An example of a release can be found [here](https://github.com/AndrewSav/remnant-two-overseer/releases/tag/v0.0.0) and this is the [build log](https://github.com/AndrewSav/remnant-two-overseer/actions/runs/16845047252)