### PR TITLE
Add ability to copy missing items list to clipboard

### DIFF
--- a/RemnantOverseer/Resources/AppStrings.de.resx
+++ b/RemnantOverseer/Resources/AppStrings.de.resx
@@ -150,6 +150,9 @@
   <data name="SaveFileLocationChanged" xml:space="preserve">
     <value>Speicherdatei-Speicherort wurde erfolgreich geändert</value>
   </data>
+  <data name="MissingItemsCopiedToClipboard" xml:space="preserve">
+    <value>Fehlende Gegenstände in die Zwischenablage kopiert</value>
+  </data>
   <data name="SelectedCharacterNotValid" xml:space="preserve">
     <value>Beim Auswählen des aktiven Charakters ist ein Problem aufgetreten. Wähle einen Charakter manuell aus</value>
   </data>

--- a/RemnantOverseer/Resources/AppStrings.es.resx
+++ b/RemnantOverseer/Resources/AppStrings.es.resx
@@ -150,6 +150,9 @@
   <data name="SaveFileLocationChanged" xml:space="preserve">
     <value>La ubicación del archivo guardado se cambió correctamente</value>
   </data>
+  <data name="MissingItemsCopiedToClipboard" xml:space="preserve">
+    <value>Objetos faltantes copiados al portapapeles</value>
+  </data>
   <data name="SelectedCharacterNotValid" xml:space="preserve">
     <value>Se produjo un problema al intentar seleccionar el personaje activo. Selecciona un personaje manualmente</value>
   </data>

--- a/RemnantOverseer/Resources/AppStrings.fr.resx
+++ b/RemnantOverseer/Resources/AppStrings.fr.resx
@@ -150,6 +150,9 @@
   <data name="SaveFileLocationChanged" xml:space="preserve">
     <value>L’emplacement du fichier de sauvegarde a bien été modifié</value>
   </data>
+  <data name="MissingItemsCopiedToClipboard" xml:space="preserve">
+    <value>Objets manquants copiés dans le presse-papiers</value>
+  </data>
   <data name="SelectedCharacterNotValid" xml:space="preserve">
     <value>Un problème est survenu lors de la sélection du personnage actif. Sélectionnez un personnage manuellement</value>
   </data>

--- a/RemnantOverseer/Resources/AppStrings.it.resx
+++ b/RemnantOverseer/Resources/AppStrings.it.resx
@@ -150,6 +150,9 @@
   <data name="SaveFileLocationChanged" xml:space="preserve">
     <value>La posizione del file di salvataggio è stata cambiata correttamente</value>
   </data>
+  <data name="MissingItemsCopiedToClipboard" xml:space="preserve">
+    <value>Oggetti mancanti copiati negli appunti</value>
+  </data>
   <data name="SelectedCharacterNotValid" xml:space="preserve">
     <value>Si è verificato un problema durante la selezione del personaggio attivo. Seleziona un personaggio manualmente</value>
   </data>

--- a/RemnantOverseer/Resources/AppStrings.ja.resx
+++ b/RemnantOverseer/Resources/AppStrings.ja.resx
@@ -150,6 +150,9 @@
   <data name="SaveFileLocationChanged" xml:space="preserve">
     <value>セーブファイルの場所を変更しました</value>
   </data>
+  <data name="MissingItemsCopiedToClipboard" xml:space="preserve">
+    <value>未取得アイテムをクリップボードにコピーしました</value>
+  </data>
   <data name="SelectedCharacterNotValid" xml:space="preserve">
     <value>アクティブなキャラクターの選択中に問題が発生しました。手動でキャラクターを選択してください</value>
   </data>

--- a/RemnantOverseer/Resources/AppStrings.ko.resx
+++ b/RemnantOverseer/Resources/AppStrings.ko.resx
@@ -150,6 +150,9 @@
   <data name="SaveFileLocationChanged" xml:space="preserve">
     <value>저장 파일 위치가 성공적으로 변경되었습니다</value>
   </data>
+  <data name="MissingItemsCopiedToClipboard" xml:space="preserve">
+    <value>누락된 아이템을 클립보드에 복사했습니다</value>
+  </data>
   <data name="SelectedCharacterNotValid" xml:space="preserve">
     <value>활성 캐릭터를 선택하는 중 문제가 발생했습니다. 캐릭터를 수동으로 선택하세요</value>
   </data>

--- a/RemnantOverseer/Resources/AppStrings.pt-BR.resx
+++ b/RemnantOverseer/Resources/AppStrings.pt-BR.resx
@@ -150,6 +150,9 @@
   <data name="SaveFileLocationChanged" xml:space="preserve">
     <value>O local do arquivo de salvamento foi alterado com sucesso</value>
   </data>
+  <data name="MissingItemsCopiedToClipboard" xml:space="preserve">
+    <value>Itens ausentes copiados para a área de transferência</value>
+  </data>
   <data name="SelectedCharacterNotValid" xml:space="preserve">
     <value>Ocorreu um problema ao tentar selecionar o personagem ativo. Selecione um personagem manualmente</value>
   </data>

--- a/RemnantOverseer/Resources/AppStrings.resx
+++ b/RemnantOverseer/Resources/AppStrings.resx
@@ -150,6 +150,9 @@
   <data name="SaveFileLocationChanged" xml:space="preserve">
     <value>Save file location was changed successfully</value>
   </data>
+  <data name="MissingItemsCopiedToClipboard" xml:space="preserve">
+    <value>Missing items copied to the clipboard</value>
+  </data>
   <data name="SelectedCharacterNotValid" xml:space="preserve">
     <value>An issue encountered when trying to select active character. Select a character manually</value>
   </data>

--- a/RemnantOverseer/Resources/AppStrings.ru.resx
+++ b/RemnantOverseer/Resources/AppStrings.ru.resx
@@ -150,6 +150,9 @@
   <data name="SaveFileLocationChanged" xml:space="preserve">
     <value>Расположение файла сохранения успешно изменено</value>
   </data>
+  <data name="MissingItemsCopiedToClipboard" xml:space="preserve">
+    <value>Недостающие предметы скопированы в буфер обмена</value>
+  </data>
   <data name="SelectedCharacterNotValid" xml:space="preserve">
     <value>Возникла проблема при выборе активного персонажа. Выберите персонажа вручную</value>
   </data>

--- a/RemnantOverseer/Resources/AppStrings.zh-Hans.resx
+++ b/RemnantOverseer/Resources/AppStrings.zh-Hans.resx
@@ -150,6 +150,9 @@
   <data name="SaveFileLocationChanged" xml:space="preserve">
     <value>存档文件位置已成功更改</value>
   </data>
+  <data name="MissingItemsCopiedToClipboard" xml:space="preserve">
+    <value>缺失物品已复制到剪贴板</value>
+  </data>
   <data name="SelectedCharacterNotValid" xml:space="preserve">
     <value>尝试选择当前角色时遇到问题。请手动选择角色</value>
   </data>

--- a/RemnantOverseer/Utilities/NotificationStrings.cs
+++ b/RemnantOverseer/Utilities/NotificationStrings.cs
@@ -14,6 +14,8 @@ internal static class NotificationStrings
 
     public static string SaveFileLocationChanged => LocalizationService.Get(nameof(SaveFileLocationChanged));
 
+    public static string MissingItemsCopiedToClipboard => LocalizationService.Get(nameof(MissingItemsCopiedToClipboard));
+
     public static string SelectedCharacterNotValid => LocalizationService.Get(nameof(SelectedCharacterNotValid));
 
     public static string NewerVersionFound => LocalizationService.Get(nameof(NewerVersionFound));

--- a/RemnantOverseer/ViewModels/MissingItemsViewModel.cs
+++ b/RemnantOverseer/ViewModels/MissingItemsViewModel.cs
@@ -1,10 +1,12 @@
-﻿using RemnantOverseer.Models.Messages;
+﻿using Avalonia.Input.Platform;
+using RemnantOverseer.Models.Messages;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using RemnantOverseer.Services;
 using RemnantOverseer.Utilities;
@@ -71,6 +73,24 @@ public partial class MissingItemsViewModel : ViewModelBase
     public void ResetFilters()
     {
         FilterText = null;
+    }
+
+    public async Task CopyToClipboardAsync(IClipboard clipboard)
+    {
+        if (FilteredItemCategories.Count == 0) return;
+
+        var sb = new StringBuilder();
+        foreach (var category in FilteredItemCategories)
+        {
+            sb.AppendLine($"- {category.Name}");
+            foreach (var item in category.Items)
+            {
+                sb.AppendLine($"  - {item.Name}");
+            }
+        }
+
+        await clipboard.SetTextAsync(sb.ToString().TrimEnd());
+        Messenger.Send(new NotificationInfoMessage(NotificationStrings.MissingItemsCopiedToClipboard));
     }
 
     private async Task ReadSave(bool resetActiveCahracter = false)

--- a/RemnantOverseer/Views/MissingItemsView.axaml
+++ b/RemnantOverseer/Views/MissingItemsView.axaml
@@ -21,7 +21,7 @@
 
   <Grid Name="OverlayGrid">
     <!-- Location selection and item tree -->
-    <Grid Name="ContentGrid" RowDefinitions="Auto, *" Margin="5">
+    <Grid Name="ContentGrid" Focusable="True" RowDefinitions="Auto, *" Margin="5">
 
       <!-- Top ribbon -->
       <Grid Grid.Row="0" Background="Transparent" ColumnDefinitions="Auto, *, Auto" Margin="10">

--- a/RemnantOverseer/Views/MissingItemsView.axaml.cs
+++ b/RemnantOverseer/Views/MissingItemsView.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using RemnantOverseer.ViewModels;
 using System;
@@ -17,5 +18,28 @@ public partial class MissingItemsView : UserControl
         base.OnLoaded(e);
         if (DataContext as MissingItemsViewModel is null) throw new Exception("DataContext is still empty");
         ((MissingItemsViewModel)DataContext).OnViewLoaded();
+
+        // Focus the content so Ctrl+C works right after switching to this tab.
+        ContentGrid.Focus();
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        if (e.Handled) return;
+        if (!e.KeyModifiers.HasFlag(KeyModifiers.Control)) return;
+        if (e.Key != Key.C && e.Key != Key.Insert) return;
+
+        // When the search box is focused, let it copy its own text.
+        if (FilterBox.IsKeyboardFocusWithin) return;
+
+        var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard is null) return;
+
+        if (DataContext is MissingItemsViewModel vm)
+        {
+            _ = vm.CopyToClipboardAsync(clipboard);
+            e.Handled = true;
+        }
     }
 }


### PR DESCRIPTION
This would close https://github.com/Angelore/remnant-two-overseer/issues/37,

When on the missing items pane pressing Ctrl-C or Ctrl-Ins would now copy the shown list of missing items to the clipboard. It is not very discoverable as is, but I'm cautious not to add more UI elements to otherwise clean design. Alternative options: surface a copy button, or add a muted text "Press ctrl-c to copy" at the top.