### PR TITLE
Hide default TitleText in Avalonia 12

### DIFF
--- a/RemnantOverseer/Views/MainWindow.axaml
+++ b/RemnantOverseer/Views/MainWindow.axaml
@@ -33,6 +33,9 @@
             </Setter.Value>
         </Setter>
     </Style>
+    <Style Selector="WindowDrawnDecorations /template/ Panel#PART_TitleTextPanel > TextBlock">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
   </Window.Styles>
 
   <Window.Resources>


### PR DESCRIPTION
I fixed titlebar from my previous PR #40 
<img width="410" height="103" alt="image" src="https://github.com/user-attachments/assets/1da76908-74b0-4522-befa-e9fe52810cf6" />
