### PR TITLE
Do not reparse unchanged world files to speed up watcher-induced save loads

### DIFF
--- a/RemnantOverseer/Services/SaveDataService.cs
+++ b/RemnantOverseer/Services/SaveDataService.cs
@@ -167,7 +167,10 @@ public class SaveDataService
                 return _dataset;
             }
 
-            var dataset = await Task.Run(() => Analyzer.Analyze(filePath ?? FilePath));
+            // Makes Analyze faster by reusing the world save parsed files that have not changed
+            // Especially noticeable on old characters, with a lot of history
+            Dataset? previous = filePath == null ? _dataset : null;
+            var dataset = await Task.Run(() => Analyzer.Analyze(filePath ?? FilePath, previous));
             _dataset = dataset;
             ResetLoadFailureNotification();
             return dataset;


### PR DESCRIPTION
This is something that I always had in the retired guardian fork that helped quite a bit to cut down on the spinner time while watching, especially with big saves / many characters. I'm not sure why it is not in Overseer, probably it was not ported for a reason, but if not, I'd like to add it, because there is a noticeable difference.