### PR TITLE
Improve Blood moon tooltip

### DIFF
--- a/RemnantOverseer/Models/BloodmoonInfo.cs
+++ b/RemnantOverseer/Models/BloodmoonInfo.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace RemnantOverseer.Models;
+
+public class BloodmoonInfo
+{
+    // All times are stored in GMT (UTC) as provided by the save file.
+    public double CurrentChance { get; set; }
+    public DateTime LastTriggeredTime { get; set; }
+    public DateTime LastCheckTime { get; set; }
+    public int ZoneLoadCount { get; set; }
+}

--- a/RemnantOverseer/Resources/AppStrings.de.resx
+++ b/RemnantOverseer/Resources/AppStrings.de.resx
@@ -266,8 +266,20 @@ Prüfe, ob die Einstellungen korrekt sind, und starte die Anwendung neu</value>
     <value>Nicht hergestellte Gegenstände mit dem
 benötigten Material im Besitz</value>
   </data>
-  <data name="World_BloodmoonChance" xml:space="preserve">
-    <value>Blutmond-Chance: {0}%</value>
+  <data name="World_BloodmoonActive" xml:space="preserve">
+    <value>Aktiviert: noch {0} Minuten</value>
+  </data>
+  <data name="World_BloodmoonCooldown" xml:space="preserve">
+    <value>Abklingzeit: {0} Minuten</value>
+  </data>
+  <data name="World_BloodmoonCooldownReady" xml:space="preserve">
+    <value>Abklingzeit: bereit</value>
+  </data>
+  <data name="World_BloodmoonChanceNextCheck" xml:space="preserve">
+    <value>Blutmond-Chance: {0}% (nächste Prüfung in {1} Minuten)</value>
+  </data>
+  <data name="World_BloodmoonChanceNextReady" xml:space="preserve">
+    <value>Blutmond-Chance: {0}% (nächste Prüfung: bereit)</value>
   </data>
   <data name="World_TraitBookAvailable" xml:space="preserve">
     <value>Eigenschaft verfügbar</value>

--- a/RemnantOverseer/Resources/AppStrings.es.resx
+++ b/RemnantOverseer/Resources/AppStrings.es.resx
@@ -266,8 +266,20 @@ Comprueba que los ajustes sean correctos y reinicia la aplicación</value>
     <value>Objetos sin fabricar con el
 material requerido en posesión</value>
   </data>
-  <data name="World_BloodmoonChance" xml:space="preserve">
-    <value>Probabilidad de luna de sangre: {0}%</value>
+  <data name="World_BloodmoonActive" xml:space="preserve">
+    <value>Activada: quedan {0} minutos</value>
+  </data>
+  <data name="World_BloodmoonCooldown" xml:space="preserve">
+    <value>Enfriamiento: {0} minutos</value>
+  </data>
+  <data name="World_BloodmoonCooldownReady" xml:space="preserve">
+    <value>Enfriamiento: listo</value>
+  </data>
+  <data name="World_BloodmoonChanceNextCheck" xml:space="preserve">
+    <value>Probabilidad de luna de sangre: {0}% (próxima comprobación en {1} minutos)</value>
+  </data>
+  <data name="World_BloodmoonChanceNextReady" xml:space="preserve">
+    <value>Probabilidad de luna de sangre: {0}% (próxima comprobación: lista)</value>
   </data>
   <data name="World_TraitBookAvailable" xml:space="preserve">
     <value>Rasgo disponible</value>

--- a/RemnantOverseer/Resources/AppStrings.fr.resx
+++ b/RemnantOverseer/Resources/AppStrings.fr.resx
@@ -266,8 +266,20 @@ Vérifiez que les paramètres sont corrects et redémarrez l’application</valu
     <value>Objets non fabriqués avec le
 matériau requis en possession</value>
   </data>
-  <data name="World_BloodmoonChance" xml:space="preserve">
-    <value>Chance de lune de sang : {0} %</value>
+  <data name="World_BloodmoonActive" xml:space="preserve">
+    <value>Activée : {0} minutes restantes</value>
+  </data>
+  <data name="World_BloodmoonCooldown" xml:space="preserve">
+    <value>Temps de recharge : {0} minutes</value>
+  </data>
+  <data name="World_BloodmoonCooldownReady" xml:space="preserve">
+    <value>Temps de recharge : prêt</value>
+  </data>
+  <data name="World_BloodmoonChanceNextCheck" xml:space="preserve">
+    <value>Chance de lune de sang : {0} % (prochaine vérification dans {1} minutes)</value>
+  </data>
+  <data name="World_BloodmoonChanceNextReady" xml:space="preserve">
+    <value>Chance de lune de sang : {0} % (prochaine vérification : prête)</value>
   </data>
   <data name="World_TraitBookAvailable" xml:space="preserve">
     <value>Trait disponible</value>

--- a/RemnantOverseer/Resources/AppStrings.it.resx
+++ b/RemnantOverseer/Resources/AppStrings.it.resx
@@ -266,8 +266,20 @@ Controlla che le impostazioni siano corrette e riavvia l’applicazione</value>
     <value>Oggetti non creati con il
 materiale richiesto in possesso</value>
   </data>
-  <data name="World_BloodmoonChance" xml:space="preserve">
-    <value>Probabilità di Luna di Sangue: {0}%</value>
+  <data name="World_BloodmoonActive" xml:space="preserve">
+    <value>Attivata: {0} minuti rimanenti</value>
+  </data>
+  <data name="World_BloodmoonCooldown" xml:space="preserve">
+    <value>Ricarica: {0} minuti</value>
+  </data>
+  <data name="World_BloodmoonCooldownReady" xml:space="preserve">
+    <value>Ricarica: pronta</value>
+  </data>
+  <data name="World_BloodmoonChanceNextCheck" xml:space="preserve">
+    <value>Probabilità di Luna di Sangue: {0}% (prossimo controllo tra {1} minuti)</value>
+  </data>
+  <data name="World_BloodmoonChanceNextReady" xml:space="preserve">
+    <value>Probabilità di Luna di Sangue: {0}% (prossimo controllo: pronto)</value>
   </data>
   <data name="World_TraitBookAvailable" xml:space="preserve">
     <value>Caratteristica disponibile</value>

--- a/RemnantOverseer/Resources/AppStrings.ja.resx
+++ b/RemnantOverseer/Resources/AppStrings.ja.resx
@@ -266,8 +266,20 @@
     <value>必要素材を所持している
 未クラフトのアイテム</value>
   </data>
-  <data name="World_BloodmoonChance" xml:space="preserve">
-    <value>ブラッドムーン確率: {0}%</value>
+  <data name="World_BloodmoonActive" xml:space="preserve">
+    <value>発生中: 残り{0}分</value>
+  </data>
+  <data name="World_BloodmoonCooldown" xml:space="preserve">
+    <value>クールダウン: {0}分</value>
+  </data>
+  <data name="World_BloodmoonCooldownReady" xml:space="preserve">
+    <value>クールダウン: 準備完了</value>
+  </data>
+  <data name="World_BloodmoonChanceNextCheck" xml:space="preserve">
+    <value>ブラッドムーン確率: {0}% (次回チェックまで{1}分)</value>
+  </data>
+  <data name="World_BloodmoonChanceNextReady" xml:space="preserve">
+    <value>ブラッドムーン確率: {0}% (次回チェック: 準備完了)</value>
   </data>
   <data name="World_TraitBookAvailable" xml:space="preserve">
     <value>特性入手可能</value>

--- a/RemnantOverseer/Resources/AppStrings.ko.resx
+++ b/RemnantOverseer/Resources/AppStrings.ko.resx
@@ -266,8 +266,20 @@
     <value>필요 재료를 보유한
 미제작 아이템</value>
   </data>
-  <data name="World_BloodmoonChance" xml:space="preserve">
-    <value>혈월 확률: {0}%</value>
+  <data name="World_BloodmoonActive" xml:space="preserve">
+    <value>발동됨: {0}분 남음</value>
+  </data>
+  <data name="World_BloodmoonCooldown" xml:space="preserve">
+    <value>재사용 대기시간: {0}분</value>
+  </data>
+  <data name="World_BloodmoonCooldownReady" xml:space="preserve">
+    <value>재사용 대기시간: 준비됨</value>
+  </data>
+  <data name="World_BloodmoonChanceNextCheck" xml:space="preserve">
+    <value>혈월 확률: {0}% (다음 확인까지 {1}분)</value>
+  </data>
+  <data name="World_BloodmoonChanceNextReady" xml:space="preserve">
+    <value>혈월 확률: {0}% (다음 확인: 준비됨)</value>
   </data>
   <data name="World_TraitBookAvailable" xml:space="preserve">
     <value>특성 획득 가능</value>

--- a/RemnantOverseer/Resources/AppStrings.pt-BR.resx
+++ b/RemnantOverseer/Resources/AppStrings.pt-BR.resx
@@ -266,8 +266,20 @@ Verifique se as configurações estão corretas e reinicie o aplicativo</value>
     <value>Itens não fabricados com o
 material necessário em posse</value>
   </data>
-  <data name="World_BloodmoonChance" xml:space="preserve">
-    <value>Chance de Lua Sangrenta: {0}%</value>
+  <data name="World_BloodmoonActive" xml:space="preserve">
+    <value>Ativada: {0} minutos restantes</value>
+  </data>
+  <data name="World_BloodmoonCooldown" xml:space="preserve">
+    <value>Recarga: {0} minutos</value>
+  </data>
+  <data name="World_BloodmoonCooldownReady" xml:space="preserve">
+    <value>Recarga: pronta</value>
+  </data>
+  <data name="World_BloodmoonChanceNextCheck" xml:space="preserve">
+    <value>Chance de Lua Sangrenta: {0}% (próxima verificação em {1} minutos)</value>
+  </data>
+  <data name="World_BloodmoonChanceNextReady" xml:space="preserve">
+    <value>Chance de Lua Sangrenta: {0}% (próxima verificação: pronta)</value>
   </data>
   <data name="World_TraitBookAvailable" xml:space="preserve">
     <value>Característica disponível</value>

--- a/RemnantOverseer/Resources/AppStrings.resx
+++ b/RemnantOverseer/Resources/AppStrings.resx
@@ -266,8 +266,20 @@ Make sure that settings are accurate and restart the application</value>
     <value>Uncrafted items with the
 required material in possession</value>
   </data>
-  <data name="World_BloodmoonChance" xml:space="preserve">
-    <value>Blood moon chance: {0}%</value>
+  <data name="World_BloodmoonActive" xml:space="preserve">
+    <value>Activated: {0} minutes left</value>
+  </data>
+  <data name="World_BloodmoonCooldown" xml:space="preserve">
+    <value>Cooldown: {0} minutes</value>
+  </data>
+  <data name="World_BloodmoonCooldownReady" xml:space="preserve">
+    <value>Cooldown: ready</value>
+  </data>
+  <data name="World_BloodmoonChanceNextCheck" xml:space="preserve">
+    <value>Blood moon chance: {0}% (next check in {1} minutes)</value>
+  </data>
+  <data name="World_BloodmoonChanceNextReady" xml:space="preserve">
+    <value>Blood moon chance: {0}% (next check: ready)</value>
   </data>
   <data name="World_TraitBookAvailable" xml:space="preserve">
     <value>Trait Book Available</value>

--- a/RemnantOverseer/Resources/AppStrings.ru.resx
+++ b/RemnantOverseer/Resources/AppStrings.ru.resx
@@ -266,8 +266,20 @@
     <value>Несозданные предметы с
 нужным материалом в наличии</value>
   </data>
-  <data name="World_BloodmoonChance" xml:space="preserve">
-    <value>Шанс Кровавой Луны: {0}%</value>
+  <data name="World_BloodmoonActive" xml:space="preserve">
+    <value>Активирована: осталось {0} мин</value>
+  </data>
+  <data name="World_BloodmoonCooldown" xml:space="preserve">
+    <value>Перезарядка: {0} мин</value>
+  </data>
+  <data name="World_BloodmoonCooldownReady" xml:space="preserve">
+    <value>Перезарядка: готова</value>
+  </data>
+  <data name="World_BloodmoonChanceNextCheck" xml:space="preserve">
+    <value>Шанс Кровавой Луны: {0}% (следующая проверка через {1} мин)</value>
+  </data>
+  <data name="World_BloodmoonChanceNextReady" xml:space="preserve">
+    <value>Шанс Кровавой Луны: {0}% (следующая проверка: готова)</value>
   </data>
   <data name="World_TraitBookAvailable" xml:space="preserve">
     <value>Доступен талант</value>

--- a/RemnantOverseer/Resources/AppStrings.zh-Hans.resx
+++ b/RemnantOverseer/Resources/AppStrings.zh-Hans.resx
@@ -266,8 +266,20 @@
     <value>拥有所需材料但
 尚未制作的物品</value>
   </data>
-  <data name="World_BloodmoonChance" xml:space="preserve">
-    <value>血月概率：{0}%</value>
+  <data name="World_BloodmoonActive" xml:space="preserve">
+    <value>已激活：剩余{0}分钟</value>
+  </data>
+  <data name="World_BloodmoonCooldown" xml:space="preserve">
+    <value>冷却时间：{0}分钟</value>
+  </data>
+  <data name="World_BloodmoonCooldownReady" xml:space="preserve">
+    <value>冷却时间：就绪</value>
+  </data>
+  <data name="World_BloodmoonChanceNextCheck" xml:space="preserve">
+    <value>血月概率：{0}%（下次检查还需{1}分钟）</value>
+  </data>
+  <data name="World_BloodmoonChanceNextReady" xml:space="preserve">
+    <value>血月概率：{0}%（下次检查：就绪）</value>
   </data>
   <data name="World_TraitBookAvailable" xml:space="preserve">
     <value>特性可获取</value>

--- a/RemnantOverseer/Utilities/DatasetMapper.cs
+++ b/RemnantOverseer/Utilities/DatasetMapper.cs
@@ -86,10 +86,17 @@ internal class DatasetMapper
         };
     }
 
-    public static float? GetBloodmoonChance(RolledWorld? world)
+    public static Models.BloodmoonInfo? GetBloodmoonInfo(RolledWorld? world)
     {
-        if (world is null) return null;
-        return world.BloodMoon?.CurrentChance is not null ? (float)Math.Round(world.BloodMoon.CurrentChance, 2, MidpointRounding.AwayFromZero) : null;
+        if (world?.BloodMoon is null) return null;
+        return new Models.BloodmoonInfo
+        {
+            CurrentChance = world.BloodMoon.CurrentChance,
+            // Save file timestamps are in GMT; mark them explicitly so local conversion works.
+            LastTriggeredTime = DateTime.SpecifyKind(world.BloodMoon.LastTriggeredTime, DateTimeKind.Utc),
+            LastCheckTime = DateTime.SpecifyKind(world.BloodMoon.LastCheckTime, DateTimeKind.Utc),
+            ZoneLoadCount = world.BloodMoon.ZoneLoadCount
+        };
     }
 
     private static List<Models.Zone> MapZonesToZones(List<Zone> zones, List<string> missingItemIds, RespawnPoint? respawnPoint)

--- a/RemnantOverseer/ViewModels/WorldViewModel.cs
+++ b/RemnantOverseer/ViewModels/WorldViewModel.cs
@@ -11,6 +11,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace RemnantOverseer.ViewModels;
@@ -65,16 +66,65 @@ public partial class WorldViewModel : ViewModelBase
     [ObservableProperty]
     private List<string> _completedQuests = [];
 
-    private float? _bloodmoonChanceCampaign = null;
-    private float? _bloodmoonChanceAdventure = null;
+    private BloodmoonInfo? _bloodmoonInfoCampaign = null;
+    private BloodmoonInfo? _bloodmoonInfoAdventure = null;
 
+    // Drives icon visibility only; the tooltip text is built on demand in GetBloodmoonTooltip.
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(BloodmoonChanceString))]
     private float? _bloodmoonChance = null;
 
-    public string BloodmoonChanceString => BloodmoonChance.HasValue
-        ? LocalizationService.Format("World_BloodmoonChance", BloodmoonChance.Value)
-        : LocalizationService.Get("Common_Unknown");
+    private BloodmoonInfo? CurrentBloodmoonInfo => IsCampaignSelected ? _bloodmoonInfoCampaign : _bloodmoonInfoAdventure;
+
+    // Non-null placeholder, so Avalonia wires it up
+    public string BloodmoonTooltip => string.Empty;
+
+    // Built on hover so the time-relative text and the optional debug lines reflect the
+    // moment the tooltip is shown.
+    public string GetBloodmoonTooltip(bool debug)
+    {
+        var info = CurrentBloodmoonInfo;
+        if (info is null) return LocalizationService.Get("Common_Unknown");
+
+        var now = DateTime.UtcNow;
+        var chance = Math.Round(info.CurrentChance, 2, MidpointRounding.AwayFromZero);
+        var sinceTriggered = now - info.LastTriggeredTime;
+        var sinceChecked = now - info.LastCheckTime;
+
+        string main;
+        if (sinceTriggered >= TimeSpan.Zero && sinceTriggered <= TimeSpan.FromMinutes(20))
+        {
+            var minutes = (int)Math.Ceiling(((info.LastTriggeredTime + TimeSpan.FromMinutes(20)) - now).TotalMinutes);
+            main = LocalizationService.Format("World_BloodmoonActive", minutes);
+        }
+        else if (sinceTriggered >= TimeSpan.Zero && sinceTriggered <= TimeSpan.FromMinutes(80))
+        {
+            var minutes = (int)Math.Ceiling(((info.LastTriggeredTime + TimeSpan.FromMinutes(80)) - now).TotalMinutes);
+            main = LocalizationService.Format("World_BloodmoonCooldown", minutes);
+        }
+        else if (info.LastTriggeredTime == info.LastCheckTime)
+        {
+            main = LocalizationService.Get("World_BloodmoonCooldownReady");
+        }
+        else if (sinceChecked >= TimeSpan.Zero && sinceChecked <= TimeSpan.FromMinutes(6))
+        {
+            var minutes = (int)Math.Ceiling(((info.LastCheckTime + TimeSpan.FromMinutes(6)) - now).TotalMinutes);
+            main = LocalizationService.Format("World_BloodmoonChanceNextCheck", chance, minutes);
+        }
+        else
+        {
+            main = LocalizationService.Format("World_BloodmoonChanceNextReady", chance);
+        }
+
+        if (!debug) return main;
+
+        var sb = new StringBuilder();
+        sb.AppendLine(main);
+        sb.AppendLine($"Current Chance: {info.CurrentChance}");
+        sb.AppendLine($"Last Triggered Time: {info.LastTriggeredTime.ToLocalTime()}");
+        sb.AppendLine($"Last Check Time: {info.LastCheckTime.ToLocalTime()}");
+        sb.Append($"Zone Load Count: {info.ZoneLoadCount}");
+        return sb.ToString();
+    }
 
     [ObservableProperty]
     private bool _hideTips;
@@ -117,7 +167,7 @@ public partial class WorldViewModel : ViewModelBase
     partial void OnIsCampaignSelectedChanged(bool value)
     {
         ApplyFilter();
-        BloodmoonChance = IsCampaignSelected ? _bloodmoonChanceCampaign : _bloodmoonChanceAdventure;
+        BloodmoonChance = CurrentBloodmoonInfo is not null ? (float)CurrentBloodmoonInfo.CurrentChance : null;
     }
 
     partial void OnHideDuplicatesChanged(bool value)
@@ -319,9 +369,9 @@ public partial class WorldViewModel : ViewModelBase
 
         ThaenTree = DatasetMapper.MapThaenTree(dataset.Characters[_selectedCharacterIndex]);
         CompletedQuests = dataset.Characters[_selectedCharacterIndex].Save.QuestCompletedLog;
-        _bloodmoonChanceCampaign = DatasetMapper.GetBloodmoonChance(dataset.Characters[_selectedCharacterIndex].Save.Campaign);
-        _bloodmoonChanceAdventure = DatasetMapper.GetBloodmoonChance(dataset.Characters[_selectedCharacterIndex].Save.Adventure);
-        BloodmoonChance = IsCampaignSelected ? _bloodmoonChanceCampaign : _bloodmoonChanceAdventure;
+        _bloodmoonInfoCampaign = DatasetMapper.GetBloodmoonInfo(dataset.Characters[_selectedCharacterIndex].Save.Campaign);
+        _bloodmoonInfoAdventure = DatasetMapper.GetBloodmoonInfo(dataset.Characters[_selectedCharacterIndex].Save.Adventure);
+        BloodmoonChance = CurrentBloodmoonInfo is not null ? (float)CurrentBloodmoonInfo.CurrentChance : null;
 
         ApplyFilter();
 
@@ -384,7 +434,7 @@ public partial class WorldViewModel : ViewModelBase
 
         Messenger.Register<WorldViewModel, CultureChangedMessage>(this, (r, m) => {
             r.ApplyFilter();
-            r.OnPropertyChanged(nameof(BloodmoonChanceString));
+            // Bloodmoon tooltip text is rebuilt on hover, so it always reflects the current culture.
             r.RefreshLocalizedTreeProperties();
         });
     }

--- a/RemnantOverseer/Views/WorldView.axaml
+++ b/RemnantOverseer/Views/WorldView.axaml
@@ -208,7 +208,7 @@
             <TreeDataTemplate DataType="models:Zone" ItemsSource="{Binding Locations}">
               <StackPanel Orientation="Horizontal">
                 <TextBlock Margin="5,0,0,0"  Text="{Binding Name}" />
-                <PathIcon Data="{StaticResource BloodmoonIcon}" Foreground="{StaticResource BloodmoonColor}" ToolTip.Tip="{Binding $parent[TreeView].((vm:WorldViewModel)DataContext).BloodmoonChanceString}" Margin="5 0" Height="16">
+                <PathIcon Data="{StaticResource BloodmoonIcon}" Foreground="{StaticResource BloodmoonColor}" ToolTip.Tip="{Binding $parent[TreeView].((vm:WorldViewModel)DataContext).BloodmoonTooltip}" PointerEntered="BloodmoonIcon_PointerEntered" Margin="5 0" Height="16">
                   <PathIcon.IsVisible>
                     <MultiBinding Converter="{x:Static BoolConverters.And}">
                       <Binding Path="CanonicalName" Converter="{StaticResource StringComparisonConverter}" ConverterParameter="{x:Static util:LocationStrings.Yaesha}" Mode="OneWay" />

--- a/RemnantOverseer/Views/WorldView.axaml.cs
+++ b/RemnantOverseer/Views/WorldView.axaml.cs
@@ -1,6 +1,8 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Media;
 using RemnantOverseer.ViewModels;
 using System;
 
@@ -24,6 +26,27 @@ public partial class WorldView : UserControl
         base.OnLoaded(e);
         if (DataContext as WorldViewModel is null) throw new Exception("DataContext is still empty");
         ((WorldViewModel)DataContext).OnViewLoaded();
+    }
+
+    // Build the bloodmoon tooltip on hover so it reflects the current time, and show the
+    // extra debug lines when Ctrl+Shift is held while mousing over.
+    private void BloodmoonIcon_PointerEntered(object? sender, PointerEventArgs e)
+    {
+        if (sender is not Control control || DataContext is not WorldViewModel vm) return;
+
+        var debug = e.KeyModifiers.HasFlag(KeyModifiers.Control) && e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+        // Supply our own ToolTip instance (Avalonia uses a Tip that is itself a ToolTip directly)
+        // so we can lift the default 320px MaxWidth for this tooltip only - other tooltips in the
+        // view still wrap as before. NoWrap then lets the box size to the widest debug line.
+        ToolTip.SetTip(control, new ToolTip
+        {
+            MaxWidth = double.PositiveInfinity,
+            Content = new TextBlock
+            {
+                Text = vm.GetBloodmoonTooltip(debug),
+                TextWrapping = TextWrapping.NoWrap
+            }
+        });
     }
 
     // Flyout can only be shown by explicitly calling it


### PR DESCRIPTION
This PR improves the Blood moon tooltip display.

When you load into an area that can have a Blood moon, the game rolls to see whether one should spawn. These checks happen on a 6-minute cooldown. The base chance is 5%, and it increases by 10% each time a roll fails to start a Blood moon. A Blood moon lasts for 20 minutes, and once it ends no checks are rolled to start a new one for 60 minutes.

The tooltip used to display "Blood moon chance: x%". Now it displays the following:
- If a Blood moon was triggered: "Activated: x minutes left", counting down the remaining portion of the 20-minute active window. Note that the Blood moon actually stays active until you load a new zone, so in practice it can persist past this countdown. Conversely, if you leave the game and reload your save, the Blood moon will no longer be there, but as long as you stay in game this will be accurate. This is shown for 20 minutes after the last Blood moon activation.
- If a Blood moon finished: "Cooldown: x minutes". This is shown for a further 60 minutes after the initial 20-minute active period has elapsed.
- If that cooldown has elapsed: "Cooldown: ready". This means the next time you transition to an eligible zone, the game will roll for a Blood moon.
- Otherwise: "Blood moon chance: x% (next check in y minutes)" or "Blood moon chance: x% (next check: ready)" -  the Blood moon chance for the next roll on transition, and when that roll can happen.

For debugging, I also added a display of the Blood moon related variables in the tooltip when Ctrl+Shift is held while hovering.

For Forgotten Kingdom DLC it keeps displaying Unknown, because there is no Blood moon there.